### PR TITLE
fix(docker): update test-harness Dockerfile for admin-gui relocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "verify:cli": "yarn workspace @portaidentity/cli verify",
     "build:gui": "yarn workspace @portaidentity/admin-gui build",
     "test:gui": "yarn workspace @portaidentity/admin-gui test",
+    "dev:gui": "yarn workspace @portaidentity/admin-gui dev",
     "verify:gui": "yarn build:cli && yarn workspace @portaidentity/admin-gui verify",
     "verify": "yarn lint && yarn build && yarn test:all && yarn verify:sdk && yarn verify:cli && yarn verify:gui",
     "migrate": "node-pg-migrate up --migrations-dir migrations --migration-file-language sql",

--- a/test-harness/Dockerfile
+++ b/test-harness/Dockerfile
@@ -24,9 +24,10 @@ RUN apk add --no-cache python3 make g++
 COPY package.json yarn.lock ./
 # Create workspace stubs so yarn resolves the workspaces field without error
 # (only name/version — no deps, keeps the install focused on server deps)
-RUN mkdir -p packages/porta-sdk packages/porta-cli \
+RUN mkdir -p packages/porta-sdk packages/porta-cli packages/porta-admin-gui \
     && echo '{"name":"@portaidentity/sdk","version":"0.1.0"}' > packages/porta-sdk/package.json \
-    && echo '{"name":"@portaidentity/cli","version":"0.1.0"}' > packages/porta-cli/package.json
+    && echo '{"name":"@portaidentity/cli","version":"0.1.0"}' > packages/porta-cli/package.json \
+    && echo '{"name":"@portaidentity/admin-gui","version":"0.1.0"}' > packages/porta-admin-gui/package.json
 RUN yarn install --production --frozen-lockfile
 
 # ─── Stage 3: Build TypeScript (Porta server) ───
@@ -34,9 +35,10 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package.json yarn.lock ./
 # Create workspace stubs so yarn resolves the workspaces field without error
-RUN mkdir -p packages/porta-sdk packages/porta-cli \
+RUN mkdir -p packages/porta-sdk packages/porta-cli packages/porta-admin-gui \
     && echo '{"name":"@portaidentity/sdk","version":"0.1.0"}' > packages/porta-sdk/package.json \
-    && echo '{"name":"@portaidentity/cli","version":"0.1.0"}' > packages/porta-cli/package.json
+    && echo '{"name":"@portaidentity/cli","version":"0.1.0"}' > packages/porta-cli/package.json \
+    && echo '{"name":"@portaidentity/admin-gui","version":"0.1.0"}' > packages/porta-admin-gui/package.json
 RUN yarn install --frozen-lockfile
 COPY tsconfig.json ./
 COPY src/ src/
@@ -44,17 +46,19 @@ RUN yarn build
 
 # ─── Stage 4: Build Admin GUI (React SPA + BFF) ───
 FROM node:22-alpine AS admin-builder
-WORKDIR /app/admin-gui
+WORKDIR /app/packages/porta-admin-gui
 
 # Copy SDK build output so file: dependency resolves
 COPY --from=sdk-builder /app/packages/porta-sdk/ /app/packages/porta-sdk/
 
-COPY admin-gui/package.json admin-gui/yarn.lock ./
+COPY packages/porta-admin-gui/package.json packages/porta-admin-gui/yarn.lock* ./
 RUN yarn install --frozen-lockfile
-COPY admin-gui/tsconfig*.json admin-gui/vite.config.ts ./
-COPY admin-gui/index.html ./
-COPY admin-gui/src/ ./src/
-COPY admin-gui/public/ ./public/
+# Symlink SDK peer dependency so TypeScript can resolve @portaidentity/sdk
+RUN mkdir -p node_modules/@portaidentity && ln -s /app/packages/porta-sdk node_modules/@portaidentity/sdk
+COPY packages/porta-admin-gui/tsconfig*.json packages/porta-admin-gui/vite.config.ts ./
+COPY packages/porta-admin-gui/index.html ./
+COPY packages/porta-admin-gui/src/ ./src/
+COPY packages/porta-admin-gui/public/ ./public/
 RUN yarn build
 
 # ─── Stage 5: Final image with pino-pretty for dev/debug logging ───
@@ -69,9 +73,9 @@ COPY package.json ./
 COPY migrations/ migrations/
 COPY templates/ templates/
 COPY locales/ locales/
-COPY --from=admin-builder /app/admin-gui/dist/ admin-gui/dist/
-COPY --from=admin-builder /app/admin-gui/node_modules/ admin-gui/node_modules/
-COPY --from=admin-builder /app/admin-gui/package.json admin-gui/package.json
+COPY --from=admin-builder /app/packages/porta-admin-gui/dist/ packages/porta-admin-gui/dist/
+COPY --from=admin-builder /app/packages/porta-admin-gui/node_modules/ packages/porta-admin-gui/node_modules/
+COPY --from=admin-builder /app/packages/porta-admin-gui/package.json packages/porta-admin-gui/package.json
 COPY docker/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 RUN printf '#!/bin/sh\nexec node /app/dist/cli/index.js "$@"\n' > /usr/local/bin/porta \


### PR DESCRIPTION
- Update all COPY paths from admin-gui/ to packages/porta-admin-gui/
- Add porta-admin-gui workspace stub to deps and builder stages
- Use yarn.lock* glob (workspace package has no lockfile)
- Symlink SDK peer dependency into admin-gui node_modules for tsc build
- Add dev:gui script to root package.json